### PR TITLE
feat: Enhance LyricLine and LyricParser for flexible lyric parsing

### DIFF
--- a/lyric-parser/include/lyricparser.h
+++ b/lyric-parser/include/lyricparser.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <optional>
 
 
 namespace Badfish::AudioToolkit
@@ -40,11 +41,14 @@ namespace Badfish::AudioToolkit
 
 struct LyricLine
 {
-    std::int64_t m_start_ms;
+    std::optional<int64_t> m_start_ms;
 
     std::string m_text;
 
-    LyricLine() : LyricLine(0, std::string()){}
+    explicit LyricLine(std::string&& text)
+        :m_text(std::move(text))
+    {
+    }
 
     LyricLine(const std::int64_t time_ms
               , std::string&& text)
@@ -69,6 +73,20 @@ struct LyricLine
     bool operator!=(const LyricLine& other) const
     {
         return (m_start_ms != other.m_start_ms) || (m_text != other.m_text);
+    }
+
+    bool isTag() const {
+        return !m_start_ms.has_value();
+    }
+
+    bool isText() const
+    {
+        return m_start_ms.has_value();
+    }
+
+    int64_t start_ms() const
+    {
+        return m_start_ms.value();
     }
 };
 
@@ -97,9 +115,11 @@ public:
                                        , std::string_view sec
                                        , std::string_view ms);
 
-    [[nodiscard]] std::vector<LyricLine> get_lrc_text() const;
+    [[nodiscard]] std::vector<LyricLine> get_lrc() const;
 
-    [[nodiscard]] std::vector<std::string> get_lyric_tags() const;
+    [[nodiscard]] std::vector<std::string> get_tags() const;
+
+    [[nodiscard]] std::vector<LyricLine> get_text() const;
 
     [[nodiscard]] bool is_enhanced() const;
 

--- a/test/TestLyricParser.cpp
+++ b/test/TestLyricParser.cpp
@@ -32,8 +32,8 @@ TEST_CASE("LyricParserNormalTest", "Normal-LRC Test")
         fileHelper.write_to_file(normal_lrc_toT, ScopedFile::Encoding::UTF8);
         const Badfish::AudioToolkit::LyricParser lyric_parser{filename};
         REQUIRE(lyric_parser.is_enhanced() == false);
-        REQUIRE(lyric_parser.get_lyric_tags() == expected_tags);
-        REQUIRE(lyric_parser.get_lrc_text() == expected_content_lines);
+        REQUIRE(lyric_parser.get_tags() == expected_tags);
+        REQUIRE(lyric_parser.get_text() == expected_content_lines);
     }
 
     SECTION("Normal-LRC Test, Encode: GBK")
@@ -43,8 +43,8 @@ TEST_CASE("LyricParserNormalTest", "Normal-LRC Test")
         Badfish::AudioToolkit::LyricParser lyric_parser{filename};
         lyric_parser.change_encoding(Badfish::FileKits::Encoding::GBK);
         REQUIRE(lyric_parser.is_enhanced() == false);
-        REQUIRE(lyric_parser.get_lyric_tags() == expected_tags);
-        REQUIRE(lyric_parser.get_lrc_text() == expected_content_lines);
+        REQUIRE(lyric_parser.get_tags() == expected_tags);
+        REQUIRE(lyric_parser.get_text() == expected_content_lines);
     }
 }
 
@@ -83,8 +83,8 @@ TEST_CASE("LyricParserEnhancedTest", "Enhanced-LRC Test")
         const Badfish::AudioToolkit::LyricParser lyric_parser{filename};
 
         REQUIRE(lyric_parser.is_enhanced() == true);
-        REQUIRE(lyric_parser.get_lyric_tags() == expected_tags);
-        REQUIRE(lyric_parser.get_lrc_text() == expected_content_lines);
+        REQUIRE(lyric_parser.get_tags() == expected_tags);
+        REQUIRE(lyric_parser.get_text() == expected_content_lines);
     }
 
     SECTION("Enhanced-LRC Test, Encode: GBK")
@@ -95,7 +95,7 @@ TEST_CASE("LyricParserEnhancedTest", "Enhanced-LRC Test")
         lyric_parser.change_encoding(Badfish::FileKits::Encoding::GBK);
 
         REQUIRE(lyric_parser.is_enhanced() == true);
-        REQUIRE(lyric_parser.get_lyric_tags() == expected_tags);
-        REQUIRE(lyric_parser.get_lrc_text() == expected_content_lines);
+        REQUIRE(lyric_parser.get_tags() == expected_tags);
+        REQUIRE(lyric_parser.get_text() == expected_content_lines);
     }
 }


### PR DESCRIPTION
# Description
Previously, struct `LyricLine` assumed all entries would have a timestamp. By changing m_start_ms from `int64_t` to `std::optional<int64_t>`, `LyricLine` can now seamlessly store both `traditional timestamped lyric lines` and `untimestamped metadata "tag" lines` (e.g., [ar:Artist Name]). 
All existing tests pass after these refactorings, ensuring no regressions.

## Type of changes
- [ ] Bug fix: Resolves an issue without altering current behavior.
- [x] Refactor: Code reorganization, no behavior change.
- [ ] Feature: New functionality without breaking existing features.
- [ ] Tests: New or modified tests